### PR TITLE
Use leading zeros in trace-id format for text headers

### DIFF
--- a/src/jaeger_passage_span_context.erl
+++ b/src/jaeger_passage_span_context.erl
@@ -229,7 +229,7 @@ get_flags_from_state(State) ->
 state_to_string(State) ->
     #?STATE{trace_id = TraceId, span_id = SpanId} = State,
     Flags = get_flags_from_state(State),
-    list_to_binary(io_lib:format("~.16b:~.16b:~.16b:~.16b",
+    list_to_binary(io_lib:format("~32.16.0b:~16.16.0b:~.16b:~.16b",
                                  [TraceId, SpanId, 0, Flags])).
 
 -spec state_from_string(binary()) -> #?STATE{}.

--- a/test/jaeger_passage_span_context_tests.erl
+++ b/test/jaeger_passage_span_context_tests.erl
@@ -56,8 +56,10 @@ propagation_test_() ->
                Span0 = passage:start_span(foo, [{tracer, tracer}]),
                Span1 = passage:set_baggage_items(Span0, #{<<"a">> => <<"b">>}),
 
-               #{<<"uber-trace-id">> := _, <<"uberctx-a">> := _} = Injected =
+               #{<<"uber-trace-id">> := TraceId, <<"uberctx-a">> := _} = Injected =
                    passage:inject_span(Span1, http_header, fun maps:put/3, #{}),
+
+               ?assertEqual(match, re:run(TraceId, <<"^[0-9a-f]{32}:[0-9a-f]{16}:0:[0-3]$">>, [{capture, none}])),
 
                Extracted =
                    passage:extract_span(


### PR DESCRIPTION
As mentioned in https://www.jaegertracing.io/docs/1.14/client-libraries/ trace-id should be padded with 0s